### PR TITLE
Tooltip track

### DIFF
--- a/docs/scripts/helper.js
+++ b/docs/scripts/helper.js
@@ -103,9 +103,9 @@ export function appendError (g, error) {
 
 
 /**
- * Génère un texte affichant une erreur
+ * Vérifie si un objet est vide ou non
  *
- * @param {object} error L'erreur à afficher
+ * @param {object} object L'objet à étudier
  */
  export function isEmptyObject (object) {
   return Object.keys(object).length === 0

--- a/docs/scripts/helper.js
+++ b/docs/scripts/helper.js
@@ -100,3 +100,16 @@ export function appendError (g, error) {
    .attr('fill', 'white')
    .text(error)
 }
+
+
+/**
+ * Génère un texte affichant une erreur
+ *
+ * @param {object} error L'erreur à afficher
+ */
+ export function isEmptyObject (object) {
+  return Object.keys(object).length === 0
+}
+
+
+

--- a/docs/scripts/tooltip.js
+++ b/docs/scripts/tooltip.js
@@ -31,7 +31,7 @@ export function getContents_Total (d) {
 }
 
 /**
- * Defines the contents of the tooltip for total heat map. See CSS for tooltip styling.
+ * Defines the contents of the tooltip for title item 
  *
  * @param {object} d The data associated to the hovered element
  * @returns {string} The tooltip contents

--- a/docs/scripts/tooltip.js
+++ b/docs/scripts/tooltip.js
@@ -39,7 +39,7 @@ export function getContents_Total (d) {
  export function getContents_Track (d) {
   // Generate tooltip contents
   let tooltip_string = '<span class="tooltip-value-streams">'
-  tooltip_string += '<strong> Artiste : </strong> '+ d.artist +'<br>'
+  if (d.artist != undefined) tooltip_string += '<strong> Artiste : </strong> '+ d.artist +'<br>'
   if (d.title != undefined) tooltip_string += '<strong> Titre : </strong> '+ d.title +'<br>'
   tooltip_string += '</span>'
   return tooltip_string

--- a/docs/scripts/tooltip.js
+++ b/docs/scripts/tooltip.js
@@ -29,3 +29,17 @@ export function getContents_Total (d) {
   tooltip_string += '</span>'
   return tooltip_string
 }
+
+/**
+ * Defines the contents of the tooltip for total heat map. See CSS for tooltip styling.
+ *
+ * @param {object} d The data associated to the hovered element
+ * @returns {string} The tooltip contents
+ */
+ export function getContents_Track (artist) {
+  // Generate tooltip contents
+  let tooltip_string = '<span class="tooltip-value-streams">'
+  tooltip_string += '<strong> Artiste : </strong> '+ artist +'<br>'
+  tooltip_string += '</span>'
+  return tooltip_string
+}

--- a/docs/scripts/tooltip.js
+++ b/docs/scripts/tooltip.js
@@ -36,10 +36,11 @@ export function getContents_Total (d) {
  * @param {object} d The data associated to the hovered element
  * @returns {string} The tooltip contents
  */
- export function getContents_Track (artist) {
+ export function getContents_Track (d) {
   // Generate tooltip contents
   let tooltip_string = '<span class="tooltip-value-streams">'
-  tooltip_string += '<strong> Artiste : </strong> '+ artist +'<br>'
+  tooltip_string += '<strong> Artiste : </strong> '+ d.artist +'<br>'
+  tooltip_string += '<strong> Titre : </strong> '+ d.title +'<br>'
   tooltip_string += '</span>'
   return tooltip_string
 }

--- a/docs/scripts/tooltip.js
+++ b/docs/scripts/tooltip.js
@@ -40,7 +40,7 @@ export function getContents_Total (d) {
   // Generate tooltip contents
   let tooltip_string = '<span class="tooltip-value-streams">'
   tooltip_string += '<strong> Artiste : </strong> '+ d.artist +'<br>'
-  tooltip_string += '<strong> Titre : </strong> '+ d.title +'<br>'
+  if (d.title != undefined) tooltip_string += '<strong> Titre : </strong> '+ d.title +'<br>'
   tooltip_string += '</span>'
   return tooltip_string
 }

--- a/docs/scripts/viz.js
+++ b/docs/scripts/viz.js
@@ -23,6 +23,8 @@ export let heatmap = {
   stat: 150
 }
 
+let pageID
+
 /**
  * Affiche les échelles de couleurs
  *
@@ -128,8 +130,16 @@ export function placeDates(id) {
       .style('fill','white')
     } else {
         setClickHandler(titleType,textSvg,complete_title,artist)
-        let tootlipContent = title == complete_title ? {artist: artist} : {artist:artist, title: complete_title}
-        if(tip != undefined) setHoverHandlerTrack(textSvg, tootlipContent, tip)
+        //Construction des données à passer au tooltip d'un item titre
+        if(tip != undefined) {
+          let tooltipContent
+          if(getPageID() == artist) tooltipContent = title == complete_title ? {} : {title: complete_title}
+          else tooltipContent = title == complete_title ? {artist: artist} : {artist:artist, title: complete_title}
+          if (!helper.isEmptyObject(tooltipContent)){
+            console.log('hello')
+            setHoverHandlerTrack(textSvg, tooltipContent, tip)
+          }
+        }
     }
     
  }
@@ -256,10 +266,10 @@ export function setHoverHandler (g, tip) {
     )
  }
 
- export function initializeViz() {
+ export function initializeViz(id) {
   //Création des groupes principaux
+  setPageID(id)
   const g = helper.generateG(index.margin, index.svgWidth, index.windowHeight)
-
   //Création du tootlip sur la heatmap
   const tip_streams = d3.tip().attr('class', 'd3-tip').html(function (d) { return tooltip.getContents_Streams(d) })
   const tip_total = d3.tip().attr('class', 'd3-tip').html(function (d) { return tooltip.getContents_Total(d) })
@@ -355,5 +365,22 @@ function setClickHandler(key,g,title,artist) {
       break
   }
 }
+
+/**
+ * Set click handler for interactivity
+ * @param {string} key 
+ */
+ function setPageID(id) {
+    pageID = id
+}
+
+/**
+ * Set click handler for interactivity
+ * @param {string} key 
+ */
+ function getPageID(id) {
+  return pageID
+}
+
 
 

--- a/docs/scripts/viz.js
+++ b/docs/scripts/viz.js
@@ -108,7 +108,7 @@ export function placeDates(id) {
  * @param {int} key L'index de la ligne pour la classe personnalisée
  * @param {boolean} isTotal
  */
- export function createLine (g, title, key, isTotal,titleType, artist, tip) {
+ export function createLine (g, title, key, isTotal, titleType, artist, tip) {
     const complete_title = title
     let textSvg = g.append('text')
      .text(title)
@@ -122,7 +122,7 @@ export function placeDates(id) {
       .style('fill','white')
     } else {
         setClickHandler(titleType,textSvg,complete_title,artist)
-        if(tip != undefined) setHoverHandlerTrack(textSvg, artist, tip)
+        if(tip != undefined) setHoverHandlerTrack(textSvg, artist, title, tip)
     }
 
     while (textSvg.node().getComputedTextLength() > heatmap.text) { //Si le titre est trop long, on le tronque
@@ -218,12 +218,12 @@ export function setHoverHandler (g, tip) {
  * @param {*} tip_streams Le tooltip pour les streams
  * @param {*} tip_total Le tooltip pour le total
  */
- export function setHoverHandlerTrack (g, artist, tip) {
+ export function setHoverHandlerTrack (g, title, artist, tip) {
   g.on('mouseover', function() {
-    tip.show(artist, this)
+    tip.show({artist: artist, title: title}, this)
   })
   .on('mouseout',  function() {
-    tip.hide(artist, this)
+    tip.hide({artist: artist, title: title}, this)
   })
   
 }

--- a/docs/scripts/viz.js
+++ b/docs/scripts/viz.js
@@ -23,7 +23,7 @@ export let heatmap = {
   stat: 150
 }
 
-let pageID
+let pageID //Variable contenant l'objet principal de la page : le pays, artiste ou titre étudié
 
 /**
  * Affiche les échelles de couleurs
@@ -106,9 +106,12 @@ export function placeDates(id) {
  * Génère le titre de la chanson pour une ligne
  *
  * @param {object} g La sélection dans laquelle on ajoute le titre
- * @param {string} title Titre de la ligne
+ * @param {string} title Texte de la ligne
  * @param {int} key L'index de la ligne pour la classe personnalisée
- * @param {boolean} isTotal
+ * @param {boolean} isTotal S'il s'agit de la ligne de total ou non pour le style
+ * @param {string} titleType Pour la redirection avec le clic vers la page associée
+ * @param {string} artist S'il s'agit d'un titre, l'artiste associé
+ * @param {object} tip Dans le cas approprié, le tooltip associé à l'item écrit
  */
  export function createLine (g, title, key, isTotal, titleType, artist, tip) {
     const complete_title = title
@@ -133,10 +136,9 @@ export function placeDates(id) {
         //Construction des données à passer au tooltip d'un item titre
         if(tip != undefined) {
           let tooltipContent
-          if(getPageID() == artist) tooltipContent = title == complete_title ? {} : {title: complete_title}
-          else tooltipContent = title == complete_title ? {artist: artist} : {artist:artist, title: complete_title}
-          if (!helper.isEmptyObject(tooltipContent)){
-            console.log('hello')
+          if(getPageID() == artist) tooltipContent = title == complete_title ? {} : {title: complete_title} //Pour la page Artiste
+          else tooltipContent = title == complete_title ? {artist: artist} : {artist:artist, title: complete_title} //Pour la page Pays et Tendances
+          if (!helper.isEmptyObject(tooltipContent)){ //Affiche le tooltip seulement s'il y a du contenu
             setHoverHandlerTrack(textSvg, tooltipContent, tip)
           }
         }
@@ -223,11 +225,11 @@ export function setHoverHandler (g, tip) {
 }
 
 /**
- * Map du hover (tooltip) pour l'interaction avec les rectangles des heatmaps
+ * Map du hover (tooltip) pour l'interaction avec les items de type titre
  *
- * @param {object} g La sélection dans laquelle on récupère les objets à map avec le tooltip
- * @param {*} tip_streams Le tooltip pour les streams
- * @param {*} tip_total Le tooltip pour le total
+ * @param {object} g Le text svg concerné par le hover
+ * @param {object} content L'objet contenant le contenu du tooltip
+ * @param {*} tip Le tooltip 
  */
  export function setHoverHandlerTrack (g, content, tip) {
   g.on('mouseover', function() {
@@ -247,6 +249,7 @@ export function setHoverHandler (g, tip) {
  * @param {object} vizWidth Largeur de la viz pour le placement des éléments
  * @param {object} tip_streams Tooltip à associer aux streams
  * @param {object} tip_total Tooltip à associer au total
+ * @param {object} tip_track Tooltip à associer à un item titre
  */
  export function appendHeatMaps(graphg, data, key, colorScales, vizWidth, tip_streams, tip_total, tip_track) {
     //Calcul du placement par rapport aux éléments précédents
@@ -266,6 +269,12 @@ export function setHoverHandler (g, tip) {
     )
  }
 
+ /**
+ * Génère les lignes
+ *
+ * @param {string} id L'ID de la page 
+ * @returns {object} les différents tooltip apparaissant sur la page
+ */
  export function initializeViz(id) {
   //Création des groupes principaux
   setPageID(id)
@@ -367,18 +376,18 @@ function setClickHandler(key,g,title,artist) {
 }
 
 /**
- * Set click handler for interactivity
- * @param {string} key 
+ * Fixe l'ID de la page
+ * @param {string} id
  */
  function setPageID(id) {
     pageID = id
 }
 
 /**
- * Set click handler for interactivity
- * @param {string} key 
+ * Renvoie l'id de la page
+ * @returns {string} l'id de la page
  */
- function getPageID(id) {
+ function getPageID() {
   return pageID
 }
 

--- a/docs/scripts/viz.js
+++ b/docs/scripts/viz.js
@@ -115,6 +115,12 @@ export function placeDates(id) {
      .attr('class', 'trackname-viz track'+String(key))
      .attr('fill', 'white')
 
+    while (textSvg.node().getComputedTextLength() > heatmap.text) { //Si le titre est trop long, on le tronque
+      title = title.slice(0, -10)
+      title = title + '...'
+      textSvg.text(title)
+    }
+
     if(isTotal){
       textSvg
       .style('font-weight', 'bold')
@@ -122,13 +128,8 @@ export function placeDates(id) {
       .style('fill','white')
     } else {
         setClickHandler(titleType,textSvg,complete_title,artist)
-        if(tip != undefined) setHoverHandlerTrack(textSvg, artist, title, tip)
-    }
-
-    while (textSvg.node().getComputedTextLength() > heatmap.text) { //Si le titre est trop long, on le tronque
-      title = title.slice(0, -10)
-      title = title + '...'
-      textSvg.text(title)
+        let tootlipContent = title == complete_title ? {artist: artist} : {artist:artist, title: complete_title}
+        if(tip != undefined) setHoverHandlerTrack(textSvg, tootlipContent, tip)
     }
     
  }
@@ -218,12 +219,12 @@ export function setHoverHandler (g, tip) {
  * @param {*} tip_streams Le tooltip pour les streams
  * @param {*} tip_total Le tooltip pour le total
  */
- export function setHoverHandlerTrack (g, title, artist, tip) {
+ export function setHoverHandlerTrack (g, content, tip) {
   g.on('mouseover', function() {
-    tip.show({artist: artist, title: title}, this)
+    tip.show(content, this)
   })
   .on('mouseout',  function() {
-    tip.hide({artist: artist, title: title}, this)
+    tip.hide(content, this)
   })
   
 }

--- a/docs/scripts/viz_ParArtiste.js
+++ b/docs/scripts/viz_ParArtiste.js
@@ -11,7 +11,7 @@ export function createArtistVisualisation(artist, start_date, end_date, country,
   const target = document.getElementsByClassName('viz-container')[0]
   const spinner = new Spinner(index.spinnerOpts).spin(target)
 
-  const tip = viz.initializeViz()
+  const tip = viz.initializeViz(artist)
 
   country = country ? country : 'global'
   country_name = country_name ? country_name : 'Mondial'
@@ -33,7 +33,7 @@ export function createArtistVisualisation(artist, start_date, end_date, country,
       let graphg = d3.select('.graph-g')
       viz.appendColumnTitles(graphg, index.vizWidth, 'Titres')
       viz.appendDates(graphg, helper.formatDate(start_date), helper.formatDate(end_date), 'Artiste')
-      viz.appendHeatMaps(graphg, data_preprocessed_artist, 'Track_Name', colorScales, index.vizWidth, tip.streams, tip.total)
+      viz.appendHeatMaps(graphg, data_preprocessed_artist, 'Track_Name', colorScales, index.vizWidth, tip.streams, tip.total, tip.track)
       viz.placeDates('Artiste')
     helper.updateSvg()
     }

--- a/docs/scripts/viz_ParPays.js
+++ b/docs/scripts/viz_ParPays.js
@@ -11,7 +11,7 @@ export function createCountryVisualisation(country, country_name, start_date, en
     const target = document.getElementsByClassName('viz-container')[0]
     const spinner = new Spinner(index.spinnerOpts).spin(target)
 
-    const tip = viz.initializeViz()
+    const tip = viz.initializeViz(country)
 
     d3.csv(index.PATH+country+'.csv', preprocess_Helpers.SpotifyDataParser).then(function (data) {
         let data_preprocessed

--- a/docs/scripts/viz_ParPays.js
+++ b/docs/scripts/viz_ParPays.js
@@ -42,7 +42,7 @@ export function createCountryVisualisation(country, country_name, start_date, en
             let graphg = d3.select('.graph-g')
             viz.appendColumnTitles(graphg, index.vizWidth, columnTitle)
             viz.appendDates(graphg, helper.formatDate(start_date), helper.formatDate(end_date), 'Pays')
-            viz.appendHeatMaps(graphg, data_preprocessed, lineTitle, colorScales, index.vizWidth, tip.streams, tip.total)
+            viz.appendHeatMaps(graphg, data_preprocessed, lineTitle, colorScales, index.vizWidth, tip.streams, tip.total, tip.track)
             viz.placeDates('Pays')
             helper.updateSvg()
         }

--- a/docs/scripts/viz_ParTendances.js
+++ b/docs/scripts/viz_ParTendances.js
@@ -60,7 +60,7 @@ export function createTrendsVisualisation(start_day,start_month,end_day,end_mont
                 //Elements généraux de la sous-vizu
                 viz.appendColumnTitles(g, trendVizWidth, 'Titres')
                 viz.appendDates(g, start_date, end_date, year.Year) 
-                viz.appendHeatMaps(g, year.Tracks, 'Track_Name', colorScales, trendVizWidth, tip.streams, tip.total)
+                viz.appendHeatMaps(g, year.Tracks, 'Track_Name', colorScales, trendVizWidth, tip.streams, tip.total, tip.track)
                 viz.placeDates(year.Year) 
                 trendVizHeight = g.node().getBBox().height
             } else {

--- a/docs/scripts/viz_ParTendances.js
+++ b/docs/scripts/viz_ParTendances.js
@@ -11,7 +11,7 @@ export function createTrendsVisualisation(start_day,start_month,end_day,end_mont
     const target = document.getElementsByClassName('viz-container')[0]
     const spinner = new Spinner(index.spinnerOpts).spin(target)
 
-    const tip = viz.initializeViz()
+    const tip = viz.initializeViz('Tendances')
 
     //paramètres par défaut
     country = country ? country : 'global'

--- a/docs/scripts/viz_ParTitre.js
+++ b/docs/scripts/viz_ParTitre.js
@@ -11,7 +11,7 @@ export function createTrackVisualisation(track, artist, countries, start_date, e
     const target = document.getElementsByClassName('viz-container')[0]
     const spinner = new Spinner(index.spinnerOpts).spin(target)
 
-    const tip = viz.initializeViz()
+    const tip = viz.initializeViz(track)
 
     let call_countries = []
     countries.forEach(country => call_countries.push(d3.csv(index.PATH+country['code']+'.csv', preprocess_Helpers.SpotifyDataParser).then(function (data) {


### PR DESCRIPTION
Ajout du tooltip sur les items de type titre
- pour les pages Pays et Tendances, tooltip indiquant l'artiste, et le titre s'il est tronqué
- pour la page artiste, tooltip indiquant le titre s'il est tronqué 
> ajout d'une variable page ID qui permet de comparer l'artiste de la page et l'artiste de l'item, pour choisir le contenu du tooltip suivant le type de la page
> ajout d'une fonction helper qui vérifie si un objet est vide ou non (pour construire le tooltip seulement s'il y a du contenu)
> création d'un tooltip supplémentaire et de sa fonction getContent associé
> adaptation des fonctions des pages et de viz pour le passage du tip
> adaptation de la fonction viz.CreateLine pour l'ajout du tooltip
> création de la fonction setHoverHandlerTrack pour l'ajout du tooltip sur le textsvg